### PR TITLE
Install to WebBindings

### DIFF
--- a/Install-CertFromKeyVault.psm1
+++ b/Install-CertFromKeyVault.psm1
@@ -48,7 +48,7 @@ function Install-CertFromKeyVault
         } else {
             if ($expiring) { 
                 Import-PfxCertificate -FilePath $certPath -CertStoreLocation cert:\LocalMachine\My 
-                Remove-Item $expiring
+                $expiring | Remove-Item
             } 
             else 
             {

--- a/Install-CertFromKeyVault.psm1
+++ b/Install-CertFromKeyVault.psm1
@@ -34,10 +34,12 @@ function Install-CertFromKeyVault
         $installed = Get-ChildItem -Path Cert:\LocalMachine -Recurse | Where-Object -Property Thumbprint -EQ $cert.Thumbprint
         $expiring = Get-ChildItem -Path Cert:\LocalMachine -Recurse | where { $_.notafter -le (Get-Date).AddDays(5) } | Where-Object -Property Subject -EQ $cert.Subject
 
+        $CertDomainRex = $CertDomain -replace "\*","[a-zA-Z0-9-_]{0,62}"
+
         if (-Not $installed) { 
             Import-PfxCertificate -FilePath $certPath -CertStoreLocation cert:\LocalMachine\My 
 
-            Get-WebBinding -Protocol Https | Where-Object {$_.bindingInformation -match "^(\*\:443\:[a-zA-Z0-9-_]{0,62}\.)$CertDomain" -and $_.sslFlags -GT 0} | select -expand bindingInformation | %{$_.split(':')[-1]} | ForEach-Object {
+            Get-WebBinding -Protocol Https | Where-Object {$_.bindingInformation -match "^(\*\:\d+\:$CertDomainRex)" -and $_.sslFlags -GT 0} | select -expand bindingInformation | %{$_.split(':')[-1]} | ForEach-Object {
 				        $binding = Get-WebBinding -HostHeader $_ -Protocol Https | Where-Object {$_.sslFlags -GT 0}
 				        if ($binding) {
 					          $binding.AddSslCertificate($cert.Thumbprint, "My")
@@ -51,7 +53,7 @@ function Install-CertFromKeyVault
             else 
             {
                 Write-Host "Certificate exists and is not close to expiring" 
-                Get-WebBinding -Protocol Https | Where-Object {$_.bindingInformation -match "^(\*\:443\:[a-zA-Z0-9-_]{0,62}\.)$CertDomain" -and $_.sslFlags -GT 0} | select -expand bindingInformation | %{$_.split(':')[-1]} | ForEach-Object {
+                Get-WebBinding -Protocol Https | Where-Object {$_.bindingInformation -match "^(\*\:\d+\:$CertDomainRex)" -and $_.sslFlags -GT 0} | select -expand bindingInformation | %{$_.split(':')[-1]} | ForEach-Object {
 				            $binding = Get-WebBinding -HostHeader $_ -Protocol Https | Where-Object {$_.sslFlags -GT 0}
 				            if ($binding) {
 					              $binding.AddSslCertificate($cert.Thumbprint, "My")

--- a/Install-CertFromKeyVault.psm1
+++ b/Install-CertFromKeyVault.psm1
@@ -32,7 +32,7 @@ function Install-CertFromKeyVault
         $cert = Get-PfxCertificate -FilePath $certPath
 
         $installed = Get-ChildItem -Path Cert:\LocalMachine -Recurse | Where-Object -Property Thumbprint -EQ $cert.Thumbprint
-        $expiring = Get-ChildItem -Path Cert:\LocalMachine -Recurse | where { $_.notafter -le (Get-Date).AddDays(5) } | Where-Object -Property Subject -EQ $cert.Subject
+        $expiring = Get-ChildItem -Path Cert:\LocalMachine -Recurse | where { $_.notafter -le (Get-Date).AddDays(5) } | Where-Object -Property Subject -like ($cert.Subject -replace "\*", "``*")
 
         $CertDomainRex = $CertDomain -replace "\*","[a-zA-Z0-9-_]{0,62}"
 

--- a/Install-CertFromKeyVault.psm1
+++ b/Install-CertFromKeyVault.psm1
@@ -37,7 +37,7 @@ function Install-CertFromKeyVault
         if (-Not $installed) { 
             Import-PfxCertificate -FilePath $certPath -CertStoreLocation cert:\LocalMachine\My 
 
-            Get-WebBinding -Protocol Https | Where-Object {$_.bindingInformation -match "^(\*\:443\:[a-zA-Z0-9-_]{0,62}\.)$CertDomain -and $_.sslFlags -GT 0"} | select -expand bindingInformation | %{$_.split(':')[-1]} | ForEach-Object {
+            Get-WebBinding -Protocol Https | Where-Object {$_.bindingInformation -match "^(\*\:443\:[a-zA-Z0-9-_]{0,62}\.)$CertDomain" -and $_.sslFlags -GT 0} | select -expand bindingInformation | %{$_.split(':')[-1]} | ForEach-Object {
 				        $binding = Get-WebBinding -HostHeader $_ -Protocol Https | Where-Object {$_.sslFlags -GT 0}
 				        if ($binding) {
 					          $binding.AddSslCertificate($cert.Thumbprint, "My")
@@ -51,7 +51,7 @@ function Install-CertFromKeyVault
             else 
             {
                 Write-Host "Certificate exists and is not close to expiring" 
-                Get-WebBinding -Protocol Https | Where-Object {$_.bindingInformation -match "^(\*\:443\:[a-zA-Z0-9-_]{0,62}\.)$CertDomain -and $_.sslFlags -GT 0"} | select -expand bindingInformation | %{$_.split(':')[-1]} | ForEach-Object {
+                Get-WebBinding -Protocol Https | Where-Object {$_.bindingInformation -match "^(\*\:443\:[a-zA-Z0-9-_]{0,62}\.)$CertDomain" -and $_.sslFlags -GT 0} | select -expand bindingInformation | %{$_.split(':')[-1]} | ForEach-Object {
 				            $binding = Get-WebBinding -HostHeader $_ -Protocol Https | Where-Object {$_.sslFlags -GT 0}
 				            if ($binding) {
 					              $binding.AddSslCertificate($cert.Thumbprint, "My")

--- a/Install-CertFromKeyVault.psm1
+++ b/Install-CertFromKeyVault.psm1
@@ -5,9 +5,7 @@ function Install-CertFromKeyVault
         [Parameter(Mandatory=$true)]
         [string] $VaultName,
         [Parameter(Mandatory=$true)]
-        [string] $CertName,
-        [Parameter(Mandatory=$true)]
-        [string] $CertDomain
+        [string] $CertName
     )
 
     Process
@@ -34,7 +32,7 @@ function Install-CertFromKeyVault
         $installed = Get-ChildItem -Path Cert:\LocalMachine -Recurse | Where-Object -Property Thumbprint -EQ $cert.Thumbprint
         $expiring = Get-ChildItem -Path Cert:\LocalMachine -Recurse | where { $_.notafter -le (Get-Date).AddDays(5) } | Where-Object -Property Subject -like ($cert.Subject -replace "\*", "``*")
 
-        $CertDomainRex = $CertDomain -replace "\*","[a-zA-Z0-9-_]{0,62}"
+        $CertDomainRex = $cert.Subject -replace "CN=", "" -replace "\*","[a-zA-Z0-9-_]{0,62}"
 
         if (-Not $installed) { 
             Import-PfxCertificate -FilePath $certPath -CertStoreLocation cert:\LocalMachine\My 


### PR DESCRIPTION
- ~Add a new argument `CertDomain`. Use to pass a string containing the FQDN of the (sub)domain you want to bind the new wildcard cert to. Example: `-CertDomain "example.com"` will install the cert on all WebBindings where hostheader matches the pattern `*.example.com`.~ Bindings are automatically matched by certificate subject.
- If cert is absent when script is ran, it will be installed and then an attempt to link it to the binding will be made.
- Will only install on WebBindings where SNI is not disabled.
